### PR TITLE
feat(play): implement Play page with question fetch & answer submission

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -13,6 +13,7 @@ admin.initializeApp({
 	projectId: process.env.FIREBASE_PROJECT_ID,
 });
 
+const db = admin.firestore();
 const app = express();
 const port = process.env.PORT || 5000;
 
@@ -23,6 +24,79 @@ app.get('/api/protected', authMiddleware, (req: Request, res: Response) => {
 	res.json({ message: 'This is a protected route.' });
 });
 
+// Interface for question data
+interface QuestionData {
+	id: string;
+	question: string;
+	clue: string;
+	answer: string;
+	difficulty: number;
+	image: string;
+}
+
+// ✅ Route: Get the current question from Firebase (protected)
+app.get("/play", authMiddleware, async (req: Request, res: Response) => {
+	try {
+		const questionsRef = db.collection('questions');
+		const snapshot = await questionsRef.get();
+		
+		if (snapshot.empty) {
+			return res.status(404).json({ error: 'No questions found in database' });
+		}
+		
+		const questions = snapshot.docs.map(doc => ({ 
+			id: doc.id, 
+			...doc.data() 
+		})) as QuestionData[];
+		
+		// Get the first (and only) question - you can change this in Firebase as needed
+		const question = questions[0];
+		
+		res.json({
+			id: question.id,
+			question: question.question,
+			hint: question.clue,
+		});
+	} catch (error) {
+		console.error('Error fetching question:', error);
+		res.status(500).json({ error: 'Failed to fetch question' });
+	}
+});
+
+// ✅ Route: Submit answer (protected)
+app.post("/play/submit", authMiddleware, async (req: Request, res: Response) => {
+	const { id, answer } = req.body;
+	
+	// Validate request body
+	if (!id || !answer) {
+		return res.status(400).json({ result: "Missing question ID or answer" });
+	}
+	
+	try {
+		const questionDoc = await db.collection('questions').doc(id).get();
+		
+		if (!questionDoc.exists) {
+			return res.status(400).json({ result: "Invalid Question ID" });
+		}
+		
+		const questionData = questionDoc.data();
+		
+		if (!questionData?.answer) {
+			return res.status(500).json({ result: "Question data is corrupted" });
+		}
+		
+		// Compare answers (case-insensitive, trimmed)
+		if (answer.trim().toLowerCase() === questionData.answer.trim().toLowerCase()) {
+			return res.json({ result: "Success 🎉 Correct Answer!" });
+		} else {
+			return res.json({ result: "Fail ❌ Wrong Answer!" });
+		}
+	} catch (error) {
+		console.error('Error validating answer:', error);
+		res.status(500).json({ result: "Error validating answer" });
+	}
+});
+
 app.listen(port, () => {
-	console.log(`Server is running on port ${port}`);
+	console.log(`Server running on port ${port}`);
 });

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -21,6 +21,7 @@
     "@tailwindcss/vite": "^4.1.13",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "firebase": "^12.2.1",
     "lucide-react": "^0.544.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/apps/frontend/src/components/ui/shadcn-io/navbar-01/index.tsx
+++ b/apps/frontend/src/components/ui/shadcn-io/navbar-01/index.tsx
@@ -147,7 +147,7 @@ export const Navbar01 = React.forwardRef<HTMLElement, Navbar01Props>(
 		}, [ref]);
 
 
-		const { user, loading } = useAuth();
+		const { user } = useAuth();
 		const navigate = useNavigate();
 
 		const handleLogout = async () => {

--- a/apps/frontend/src/pages/PlayPage.tsx
+++ b/apps/frontend/src/pages/PlayPage.tsx
@@ -1,22 +1,98 @@
 import { Navbar01 } from "@/components/ui/shadcn-io/navbar-01";
+import { useState, useEffect } from "react";
+import { useAuth } from "../context/AuthContext";
 
-// Imports will go here
-// - React
-// - Game components
-// - Auth context (for checking authentication)
-// frontend/src/pages/PlayPage.tsx
-export default function PlayPage() {
-	return (
-		<div className="relative w-full">
-			<Navbar01 />
-			<div className="flex flex-col items-center justify-center min-h-screen">
-				<h1 className="text-2xl font-bold">Play Page</h1>
-				<p className="text-gray-600">Game interface will go here</p>
-			</div>
-		</div>
-	);
+function PlayPage() {
+  const { user } = useAuth();
+  const [questionId, setQuestionId] = useState(""); // ✅ Add this to store the question ID
+  const [question, setQuestion] = useState("");
+  const [hint, setHint] = useState("");
+  const [answer, setAnswer] = useState("");
+  const [result, setResult] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    // Fetch question on load
+    const fetchQuestion = async () => {
+      try {
+        const token = await user?.getIdToken();
+        const response = await fetch("http://localhost:5000/play", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const data = await response.json();
+        setQuestionId(data.id); // ✅ Store the question ID
+        setQuestion(data.question);
+        setHint(data.hint);
+      } catch (error) {
+        console.error("Error fetching question:", error);
+        setResult("Error loading question");
+      }
+    };
+
+    if (user) {
+      fetchQuestion();
+    }
+  }, [user]);
+
+  const submitAnswer = async () => {
+    setLoading(true);
+    try {
+      const token = await user?.getIdToken();
+      const response = await fetch("http://localhost:5000/play/submit", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ id: questionId, answer }), // ✅ Use the actual question ID
+      });
+      const data = await response.json();
+      setResult(data.result);
+    } catch (error) {
+      console.error("Error submitting answer:", error);
+      setResult("Error submitting answer");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white p-8">
+      <Navbar01 navigationLinks={[
+        { href: '/', label: 'Home' },
+        { href: '/rules', label: 'Rules' },
+        { href: '/leaderboard', label: 'Leaderboard' },
+        { href: '/', label: 'Contact' },
+      ]} />
+      
+      <div className="max-w-2xl mx-auto mt-8 space-y-6">
+        <h2 className="text-3xl font-bold text-white mb-4">{question}</h2>
+        <p className="text-lg text-gray-300">Hint: {hint}</p>
+        
+        <div className="space-y-4">
+          <input
+            value={answer}
+            onChange={(e) => setAnswer(e.target.value)}
+            placeholder="Your answer"
+            className="w-full p-3 bg-gray-800 text-white border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <button 
+            onClick={submitAnswer}
+            disabled={loading}
+            className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? "Submitting..." : "Submit"}
+          </button>
+        </div>
+        
+        {result && (
+          <p className="text-lg font-semibold text-white p-4 bg-gray-800 rounded-lg">
+            {result}
+          </p>
+        )}
+      </div>
+    </div>
+  );
 }
 
-// Will contain:
-// - Game interface
-// - Protected route logic (redirect to sign in if not authenticated)
+export default PlayPage;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      firebase:
+        specifier: ^12.2.1
+        version: 12.2.1
       lucide-react:
         specifier: ^0.544.0
         version: 0.544.0(react@19.1.1)


### PR DESCRIPTION
**Backend Changes (apps/backend/src/index.ts)**

Firebase Admin Setup
Initialized Firebase Admin SDK using a serviceAccountKey.json file.
Loaded environment variables (.env) for FIREBASE_PROJECT_ID.
Enabled secure Firestore access via admin.initializeApp().

Database
Used Firestore (admin.firestore()) as the question database.

Middleware already did 
Integrated a custom authMiddleware to verify Firebase ID tokens, ensuring that only authenticated users can access the Play API.

API Endpoints
GET /play (Protected)
Fetches the current question from the questions collection in Firestore.
Returns id, question, and hint (clue) to the client.
POST /play/submit (Protected)
Accepts { id, answer } from the client.
Retrieves the corresponding Firestore document and validates the submitted answer (case-insensitive, trimmed).
Responds with Success 🎉 or Fail ❌ message.


**Frontend Changes (apps/frontend/src/pages/PlayPage.tsx)**

needs ui improvement although 
Play Page UI is built
Built a responsive page with:
Question display
Hint display
Input box for user answer

Submit button with loading state
Result feedback section
Authentication
Used useAuth() context to get the Firebase user and retrieve an ID token.
Attached Authorization: Bearer <token> header in all API requests.

**Data Flow**
On Page Load:
Fetches a question via GET /play using the ID token.
Stores question ID to match answers when submitting.

On Answer Submit:
Sends { id, answer } via POST /play/submit.
Displays server result (Correct or Wrong).
UI Enhancements
Styled using Tailwind + Shadcn components (Navbar01).
Clean dark theme with a modern game-like interface.



