### PR TITLE
feat: improve day unlock logic, unify Leaderboard styling, add final day completion popup

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -46,13 +46,16 @@ app.get("/test", (req, res) => {
   });
 });
 
-// Utility function
-const getCurrentDay = (): number => {
-  const startDate = new Date("2025-09-30");
-  const today = new Date();
-  const diffTime = today.getTime() - startDate.getTime();
-  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-  return Math.min(Math.max(diffDays, 1), 10);
+const getCurrentDay = async () => {
+  const snapshot = await db.collection("questions").orderBy("day").get();
+  const now = new Date();
+
+  const unlockedCount = snapshot.docs.filter(doc => {
+    const d = doc.data().unlockDate?.toDate();
+    return d && d <= now;
+  }).length;
+
+  return Math.max(1, unlockedCount);
 };
 
 // Make db and getCurrentDay available to routes

--- a/apps/backend/src/routes/authRoutes.ts
+++ b/apps/backend/src/routes/authRoutes.ts
@@ -68,7 +68,7 @@ router.get(
       const userData = userDoc.data();
       res.json({
         user: { id: userDoc.id, ...userData },
-        currentDay: getCurrentDay(),
+        currentDay: await getCurrentDay(),
       });
     } catch (error) {
       console.error("Error fetching user progress:", error);

--- a/apps/backend/src/routes/leaderboardRoutes.ts
+++ b/apps/backend/src/routes/leaderboardRoutes.ts
@@ -53,7 +53,7 @@ router.get("/leaderboard/:day", async (req: Request, res: Response) => {
 
 router.get("/leaderboard", async (req: Request, res: Response) => {
   const { getCurrentDay } = req.app.locals;
-  const currentDay = getCurrentDay();
+  const currentDay = await getCurrentDay();
   return res.redirect(`/leaderboard/${currentDay}`);
 });
 

--- a/apps/backend/src/routes/questionRoutes.ts
+++ b/apps/backend/src/routes/questionRoutes.ts
@@ -24,7 +24,7 @@ router.get("/play", authMiddleware, async (req: Request, res: Response) => {
     const requestedDay = req.query.day
       ? parseInt(req.query.day as string)
       : null;
-    const currentDay = requestedDay || getCurrentDay();
+    const currentDay = requestedDay || await getCurrentDay();
 
     // Fetch question document
     const questionRef = db.collection("questions").doc(`day${currentDay}`);
@@ -65,7 +65,7 @@ router.get("/play", authMiddleware, async (req: Request, res: Response) => {
     const userData = userDoc.exists ? userDoc.data() || {} : {};
 
     // Check serial progression
-    const progression = checkSerialProgression(
+    const progression = await checkSerialProgression(
       currentDay,
       requestedDay,
       userData,
@@ -123,7 +123,7 @@ router.get("/progress", authMiddleware, async (req: Request, res: Response) => {
     const userDoc = await userRef.get();
     const userData = userDoc.exists ? userDoc.data() || {} : {};
 
-    const currentDay = getCurrentDay();
+    const currentDay = await getCurrentDay();
 
     // OPTIMIZATION: Fetch all question documents in parallel
     const questionPromises = Array.from({ length: totalDays }, (_, i) => {

--- a/apps/backend/src/utilities/questionRouteHelpers.ts
+++ b/apps/backend/src/utilities/questionRouteHelpers.ts
@@ -98,12 +98,12 @@ export const isDayCompleted = (userData: UserData, day: number): boolean => {
 /**
  * Check serial progression and determine if day is accessible
  */
-export const checkSerialProgression = (
+export const checkSerialProgression = async (
   currentDay: number,
   requestedDay: number | null,
   userData: UserData,
   getCurrentDay: () => number,
-): { isUnlocked: boolean; lockReason: string; isCatchUp: boolean } => {
+): Promise<{ isUnlocked: boolean; lockReason: string; isCatchUp: boolean; }> => {
   if (currentDay === 1) {
     return { isUnlocked: true, lockReason: "", isCatchUp: false };
   }
@@ -116,8 +116,8 @@ export const checkSerialProgression = (
 
   // Handle catch-up mode
   if (requestedDay) {
-    const isPreviousDay = requestedDay < getCurrentDay();
-    const isCurrentDay = requestedDay === getCurrentDay();
+    const isPreviousDay = requestedDay < await getCurrentDay();
+    const isCurrentDay = requestedDay === await getCurrentDay();
 
     if (isPreviousDay || isCurrentDay) {
       return {

--- a/apps/frontend/src/components/play/ProgressGrid.tsx
+++ b/apps/frontend/src/components/play/ProgressGrid.tsx
@@ -12,7 +12,6 @@ interface Props {
   days: Day[];
   displayDay: number;
   onSelectDay: (day: number) => void;
-  maxAccessibleDay: number;
 }
 
 /**
@@ -20,14 +19,14 @@ interface Props {
  * Clicking an available day will call onSelectDay(day).
  * Memoized to prevent unnecessary re-renders.
  */
-const ProgressGrid = memo(function ProgressGrid({ days, displayDay, onSelectDay, maxAccessibleDay }: Props) {
+const ProgressGrid = memo(function ProgressGrid({ days, displayDay, onSelectDay }: Props) {
   return (
     <div className="flex flex-col flex-grow min-h-0 bg-white/5 backdrop-blur-lg border border-white/10 rounded-lg p-6 shadow-md">
       <h3 className="text-lg font-semibold mb-4">Your Progress</h3>
 
       <div className="grid grid-cols-2 md:grid-cols-3 gap-3 flex-grow min-h-0 overflow-y-auto scrollbar-thin scrollbar-thumb-purple-600/40 scrollbar-track-transparent">
         { days ? days.map((d) => {
-          const isAvailable = d.isAccessible && d.day <= maxAccessibleDay && d.isDateUnlocked !== false;
+          const isAvailable = d.isAccessible && d.isDateUnlocked !== false;
           return (
             <div
               key={d.day}

--- a/apps/frontend/src/hooks/usePlay.ts
+++ b/apps/frontend/src/hooks/usePlay.ts
@@ -126,7 +126,7 @@ export function usePlay(user: any) {
   const fetchQuestion = useCallback(async (day?: number) => {
     if (!user) return null;
 
-    const currentDay = getCurrentDay();
+    const currentDay = await getCurrentDay();
     const targetDay = typeof day === 'number' ? day : currentDay;
     const allowedDay = Math.min(targetDay, currentDay);
 
@@ -244,7 +244,7 @@ export function usePlay(user: any) {
 
         // Auto-navigate to next question if it exists and is unlocked
         if (updatedProgress) {
-          const currentDay = getCurrentDay();
+          const currentDay = await getCurrentDay();
           const nextDay = displayDay + 1;
           const maxDay = Math.min(currentDay, updatedProgress.totalDays || currentDay);
 
@@ -279,7 +279,7 @@ export function usePlay(user: any) {
       const p = await fetchProgress();
       if (p) {
         // find first incomplete accessible day (client-side)
-        const currentDay = getCurrentDay();
+        const currentDay = await getCurrentDay();
         const accessibleMax = Math.min(currentDay, p.totalDays || currentDay);
         const firstIncomplete = p.progress.find(d => !d.isCompleted && d.isAccessible && (d.day <= accessibleMax));
         const recommended = firstIncomplete ? firstIncomplete.day : Math.min(accessibleMax, p.totalDays || accessibleMax);

--- a/apps/frontend/src/pages/LeaderboardPage.tsx
+++ b/apps/frontend/src/pages/LeaderboardPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useAuth } from "../contexts/AuthContext";
-import { getCurrentDay, getDailyLeaderboard, getEnhancedDailyLeaderboard } from "../services/firestoreService";
+import { getCurrentDay, getEnhancedDailyLeaderboard } from "../services/firestoreService";
 import { Button } from "@/components/ui/button";
 import { motion } from "framer-motion";
 
@@ -22,10 +22,14 @@ export default function LeaderboardPage() {
   const [userRank, setUserRank] = useState<number | null>(null);
 
   useEffect(() => {
-    const day = getCurrentDay();
-    setCurrentDay(day);
-    setSelectedDay(day);
-    fetchLeaderboard(day);
+    const load = async () => {
+      const day = await getCurrentDay();
+      setCurrentDay(day);
+      setSelectedDay(day);
+      fetchLeaderboard(day);
+    };
+
+    load();
   }, []);
 
   const fetchLeaderboard = async (day: number) => {
@@ -106,9 +110,7 @@ export default function LeaderboardPage() {
             <div className="flex flex-wrap gap-2">
               {Array.from({ length: 5 }, (_, i) => {
                 const day = i + 1;
-                const isCurrentDay = day === currentDay;
                 const isSelected = day === selectedDay;
-                const isPastDay = day < currentDay;
 
                 return (
                   <Button

--- a/apps/frontend/src/pages/LeaderboardPage.tsx
+++ b/apps/frontend/src/pages/LeaderboardPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useAuth } from "../contexts/AuthContext";
-import { getCurrentDay, getDailyLeaderboard } from "../services/firestoreService";
+import { getCurrentDay, getDailyLeaderboard, getEnhancedDailyLeaderboard } from "../services/firestoreService";
 import { Button } from "@/components/ui/button";
 import { motion } from "framer-motion";
 
@@ -9,6 +9,7 @@ interface LeaderboardEntry {
   name: string;
   email: string;
   completedAt: any;
+  attempts: number;
   rank: number;
 }
 
@@ -30,7 +31,8 @@ export default function LeaderboardPage() {
   const fetchLeaderboard = async (day: number) => {
     setLoading(true);
     try {
-      const data = await getDailyLeaderboard(day, 20);
+      // Use enhanced leaderboard with attempts tracking
+      const data = await getEnhancedDailyLeaderboard(day, 20);
       setLeaderboard(data);
 
       if (currentUser) {
@@ -67,14 +69,20 @@ export default function LeaderboardPage() {
     return `#${rank}`;
   };
 
+  // Get the date for each day (Nov 17-22, 2025)
+  const getDayDate = (day: number): string => {
+    const dates = ["Nov 17", "Nov 18", "Nov 19", "Nov 20", "Nov 21", "Nov 22"];
+    return dates[day - 1] || "";
+  };
+
   return (
     <motion.div
-      initial={{ opacity: 0, y: 20 }}
+      initial={{ opacity: 0, y: -20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6, ease: "easeOut" }}
-      className="relative w-full min-h-screen pt-24 bg-transparent pb-8 lg:pb-4"
+      className="min-h-screen bg-transparent pt-14"
     >
-      <div className="container mx-auto px-4 md:px-6 py-8">
+      <div className="container mx-auto px-4 md:px-6 pt-20 font-orbitron">
 
         {/* Header */}
         <div className="text-center mb-8">
@@ -84,100 +92,132 @@ export default function LeaderboardPage() {
           <p className="text-gray-300 text-lg">
             See who completed today's challenge the fastest!
           </p>
+          <p className="text-gray-400 text-sm mt-2">
+            Challenge runs from November 17-22, 2025
+          </p>
         </div>
 
-        {/* Day Selector */}
-        <div className="bg-white/5 backdrop-blur-lg border border-white/10 rounded-lg p-6 mb-8">
-          <h2 className="text-xl font-semibold text-white mb-4">
-            Select Day
-          </h2>
-          <div className="flex flex-wrap gap-2">
-            {Array.from({ length: 10 }, (_, i) => {
-              const day = i + 1;
-              const isCurrentDay = day === currentDay;
-              const isSelected = day === selectedDay;
-
-              return (
-                <Button
-                  key={day}
-                  onClick={() => handleDayChange(day)}
-                  variant={isSelected ? "default" : "outline"}
-                  className={`${isCurrentDay && !isSelected
-                    ? "bg-white/20 border-white text-white hover:bg-white/30"
-                    : ""}`}
-                >
-                  Day {day}
-                  {isCurrentDay && " (Today)"}
-                </Button>
-              );
-            })}
-          </div>
-        </div>
-
-        {/* User Rank */}
-        {currentUser && userRank && (
-          <div className="bg-white/10 border border-white/20 text-white px-6 py-4 rounded-lg mb-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <h3 className="text-lg font-semibold">Your Ranking</h3>
-                <p className="text-sm">
-                  You are ranked #{userRank} for Day {selectedDay}
-                </p>
-              </div>
-              <div className="text-2xl">{getRankIcon(userRank)}</div>
-            </div>
-          </div>
-        )}
-
-        {/* Leaderboard */}
-        <div className="bg-white/5 backdrop-blur-lg border border-white/10 rounded-lg overflow-hidden">
-          <div className="bg-white/10 px-6 py-4">
-            <h2 className="text-xl font-semibold text-white">
-              Day {selectedDay} Leaderboard
-              {selectedDay === currentDay && " (Today)"}
+        <div className="space-y-6">
+          {/* Day Selector */}
+          <div className="bg-white/5 backdrop-blur-lg border border-white/10 rounded-lg p-6">
+            <h2 className="text-xl font-semibold text-white mb-4">
+              Select Day
             </h2>
+            <div className="flex flex-wrap gap-2">
+              {Array.from({ length: 5 }, (_, i) => {
+                const day = i + 1;
+                const isCurrentDay = day === currentDay;
+                const isSelected = day === selectedDay;
+                const isPastDay = day < currentDay;
+
+                return (
+                  <Button
+                    key={day}
+                    onClick={() => handleDayChange(day)}
+                    variant={isSelected ? "default" : "outline"}
+                    disabled={day > currentDay}
+                    className={`transition-all ${
+                      isSelected 
+                        ? "bg-white text-black hover:bg-gray-200" 
+                        : day > currentDay
+                        ? "opacity-40 cursor-not-allowed"
+                        : "bg-transparent border-white/30 text-white hover:bg-white/10"
+                    }`}
+                  >
+                    <div className="flex flex-col items-center">
+                      <span>Day {day}</span>
+                      <span className="text-xs opacity-70">
+                        {getDayDate(day)}
+                      </span>
+                    </div>
+                  </Button>
+                );
+              })}
+            </div>
           </div>
 
-          {loading ? (
-            <div className="p-8 text-center">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white mx-auto"></div>
-              <p className="text-gray-300 mt-2">Loading leaderboard...</p>
+          {/* User Rank */}
+          {currentUser && userRank && (
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              className="bg-white/10 backdrop-blur-lg border border-white/20 text-white px-6 py-4 rounded-lg"
+            >
+              <div className="flex items-center justify-between">
+                <div>
+                  <h3 className="text-lg font-semibold">Your Ranking</h3>
+                  <p className="text-sm text-gray-300">
+                    You are ranked #{userRank} for Day {selectedDay} ({getDayDate(selectedDay)})
+                  </p>
+                </div>
+                <div className="text-3xl">{getRankIcon(userRank)}</div>
+              </div>
+            </motion.div>
+          )}
+
+          {/* Leaderboard */}
+          <div className="bg-white/5 backdrop-blur-lg border border-white/10 rounded-lg overflow-hidden">
+            <div className="bg-white/10 px-6 py-4 border-b border-white/10">
+              <h2 className="text-xl font-semibold text-white">
+                Day {selectedDay} - {getDayDate(selectedDay)} Leaderboard
+                {selectedDay === currentDay && " (Today)"}
+              </h2>
             </div>
-          ) : leaderboard.length === 0 ? (
-            <div className="p-8 text-center text-gray-300">
-              No completions yet.
-            </div>
-          ) : (
-            <div className="divide-y divide-white/10">
-              {leaderboard.map((entry) => (
-                <div
-                  key={entry.id}
-                  className={`px-6 py-4 flex items-center justify-between ${
-                    currentUser && entry.id === currentUser.uid ? 'bg-white/10' : ''
-                  }`}
-                >
-                  <div className="flex items-center space-x-4">
-                    <div className="text-2xl min-w-[3rem] text-white">
-                      {getRankIcon(entry.rank)}
+
+            {loading ? (
+              <div className="p-8 text-center">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white mx-auto"></div>
+                <p className="text-gray-300 mt-2">Loading leaderboard...</p>
+              </div>
+            ) : leaderboard.length === 0 ? (
+              <div className="p-8 text-center text-gray-300">
+                <div className="text-4xl mb-2">🏆</div>
+                No completions yet for this day.
+              </div>
+            ) : (
+              <div className="divide-y divide-white/10">
+                {leaderboard.map((entry, index) => (
+                  <motion.div
+                    key={entry.id}
+                    initial={{ opacity: 0, x: -20 }}
+                    animate={{ opacity: 1, x: 0 }}
+                    transition={{ delay: index * 0.05 }}
+                    className={`px-6 py-4 flex items-center justify-between transition-colors ${
+                      currentUser && entry.id === currentUser.uid 
+                        ? 'bg-white/15 border-l-4 border-l-white' 
+                        : 'hover:bg-white/5'
+                    }`}
+                  >
+                    <div className="flex items-center space-x-4 flex-1">
+                      <div className="text-2xl min-w-[3.5rem] text-white font-bold">
+                        {getRankIcon(entry.rank)}
+                      </div>
+                      <div className="flex-1">
+                        <h3 className="text-sm lg:text-lg font-semibold text-white">
+                          {entry.name || 'Anonymous'}
+                          {currentUser && entry.id === currentUser.uid && ' (You)'}
+                        </h3>
+                        <p className="text-[10px] lg:text-sm text-gray-300">
+                          {entry.email}
+                        </p>
+                        <p className="text-xs text-gray-400 mt-1">
+                          Attempts: {entry.attempts}
+                        </p>
+                      </div>
                     </div>
-                    <div>
-                      <h3 className="text-sm lg:text-lg font-semibold text-white">
-                        {entry.name || 'Anonymous'}
-                        {currentUser && entry.id === currentUser.uid && ' (You)'}
-                      </h3>
-                      <p className="text-[10px] lg:text-sm text-gray-300">
-                        {entry.email}
+                    <div className="text-right text-white">
+                      <p className="text-[10px] lg:text-xs text-gray-400 uppercase tracking-wide">
+                        Completed
+                      </p>
+                      <p className="text-sm lg:text-lg font-semibold">
+                        {formatTime(entry.completedAt)}
                       </p>
                     </div>
-                  </div>
-                  <div className="text-right text-white">
-                    <p className="text-[12px] lg:text-sm text-gray-300">Completed at</p>
-                    <p className="text-[14px] lg:text-lg">{formatTime(entry.completedAt)}</p>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
+                  </motion.div>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </motion.div>

--- a/apps/frontend/src/pages/LeaderboardPage.tsx
+++ b/apps/frontend/src/pages/LeaderboardPage.tsx
@@ -73,11 +73,6 @@ export default function LeaderboardPage() {
     return `#${rank}`;
   };
 
-  // Get the date for each day (Nov 17-22, 2025)
-  const getDayDate = (day: number): string => {
-    const dates = ["Nov 17", "Nov 18", "Nov 19", "Nov 20", "Nov 21", "Nov 22"];
-    return dates[day - 1] || "";
-  };
 
   return (
     <motion.div
@@ -94,10 +89,7 @@ export default function LeaderboardPage() {
             Daily Leaderboard
           </h1>
           <p className="text-gray-300 text-lg">
-            See who completed today's challenge the fastest!
-          </p>
-          <p className="text-gray-400 text-sm mt-2">
-            Challenge runs from November 17-22, 2025
+            See who completed challenge the fastest!
           </p>
         </div>
 
@@ -128,9 +120,6 @@ export default function LeaderboardPage() {
                   >
                     <div className="flex flex-col items-center">
                       <span>Day {day}</span>
-                      <span className="text-xs opacity-70">
-                        {getDayDate(day)}
-                      </span>
                     </div>
                   </Button>
                 );
@@ -149,7 +138,7 @@ export default function LeaderboardPage() {
                 <div>
                   <h3 className="text-lg font-semibold">Your Ranking</h3>
                   <p className="text-sm text-gray-300">
-                    You are ranked #{userRank} for Day {selectedDay} ({getDayDate(selectedDay)})
+                    You are ranked #{userRank} for Day {selectedDay}
                   </p>
                 </div>
                 <div className="text-3xl">{getRankIcon(userRank)}</div>
@@ -161,7 +150,7 @@ export default function LeaderboardPage() {
           <div className="bg-white/5 backdrop-blur-lg border border-white/10 rounded-lg overflow-hidden">
             <div className="bg-white/10 px-6 py-4 border-b border-white/10">
               <h2 className="text-xl font-semibold text-white">
-                Day {selectedDay} - {getDayDate(selectedDay)} Leaderboard
+                Day {selectedDay} - Leaderboard
                 {selectedDay === currentDay && " (Today)"}
               </h2>
             </div>

--- a/apps/frontend/src/pages/PlayPage.tsx
+++ b/apps/frontend/src/pages/PlayPage.tsx
@@ -68,6 +68,14 @@ function PlayPage() {
     }
   };
   const [isOpen, setIsOpen] = useState(false);
+  const [showFinalCongrats, setShowFinalCongrats] = useState(false);
+  useEffect(() => {
+    if (question?.isCompleted && displayDay === progress?.progress.length) {
+      setShowFinalCongrats(true);
+    }
+  }, [question, displayDay, progress]);
+
+
 
 
   return (
@@ -79,7 +87,7 @@ function PlayPage() {
       <div className="container mx-auto px-4 md:px-6 pt-20 font-orbitron">
 
         <div className="space-y-6">
-          <DayProgress day={displayDay} totalDays={progress?.progress.length} setIsOpen={setIsOpen}/>
+          <DayProgress day={displayDay} totalDays={progress?.progress.length} setIsOpen={setIsOpen} />
           <div className='flex flex-col lg:flex-row lg:items-start lg:justify-center gap-8 w-full flex-grow min-h-0'>
 
             <div className='flex flex-col lg:flex-row gap-6 lg:w-[70%] items-center justify-between flex-shrink-0 mx-auto'>
@@ -124,26 +132,26 @@ function PlayPage() {
                   </div>
                 ) : (
                   <div className='flex flex-col gap-12 p-1 md:p-0'>
-                      <div>{question?.question}</div>
-                      <div className='flex flex-col gap-2 '>
+                    <div>{question?.question}</div>
+                    <div className='flex flex-col gap-2 '>
 
-                        <div className='md:text-3xl text-xl'>Answer :</div>
-                        <Input
-                          id="answer-input"
-                          placeholder="Enter answer"
-                          value={answer}
-                          onChange={(e: any) => setAnswer(e.target.value)}
-                          disabled={cooldownSeconds > 0 || submitting}
-                          onKeyDown={(e: any) => e.key === 'Enter' && handleSubmit()}
-                        />
-                        <div className="mt-3 flex gap-2">
-                          <Button onClick={handleSubmit} disabled={submitting || cooldownSeconds > 0} className="flex-1">
-                            {submitting ? 'Submitting...' : cooldownSeconds > 0 ? `Wait ${cooldownSeconds}s` : 'Submit'}
-                          </Button>
-                        </div>
-                        {message && <div className="mt-3 text-sm text-muted-foreground">{message}</div>}
-
+                      <div className='md:text-3xl text-xl'>Answer :</div>
+                      <Input
+                        id="answer-input"
+                        placeholder="Enter answer"
+                        value={answer}
+                        onChange={(e: any) => setAnswer(e.target.value)}
+                        disabled={cooldownSeconds > 0 || submitting}
+                        onKeyDown={(e: any) => e.key === 'Enter' && handleSubmit()}
+                      />
+                      <div className="mt-3 flex gap-2">
+                        <Button onClick={handleSubmit} disabled={submitting || cooldownSeconds > 0} className="flex-1">
+                          {submitting ? 'Submitting...' : cooldownSeconds > 0 ? `Wait ${cooldownSeconds}s` : 'Submit'}
+                        </Button>
                       </div>
+                      {message && <div className="mt-3 text-sm text-muted-foreground">{message}</div>}
+
+                    </div>
                   </div>
                 )}
               </div>
@@ -219,6 +227,47 @@ function PlayPage() {
             )}
           </AnimatePresence>
         </div>
+
+        <AnimatePresence>
+  {showFinalCongrats && (
+    <motion.div
+      className="fixed inset-0 bg-black/40 backdrop-blur-sm flex items-center justify-center z-50"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+    >
+      <motion.div
+        className="rounded-2xl p-6 max-w-md w-full mx-4 text-center 
+                   bg-white/10 border border-white/20 backdrop-blur-xl shadow-xl"
+        initial={{ scale: 0.8, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        exit={{ scale: 0.8, opacity: 0 }}
+        transition={{ duration: 0.3 }}
+      >
+        <h2 className="text-2xl font-semibold text-white mb-4 tracking-wide">
+          🎉 Congratulations! 🎉
+        </h2>
+
+        <p className="text-gray-200 leading-relaxed">
+          You’ve completed all available challenges!<br />
+          Absolute legend energy.
+        </p>
+
+        <div className="mt-6">
+          <button
+            onClick={() => setShowFinalCongrats(false)}
+            className="px-6 py-2.5 rounded-lg bg-white/20 text-white 
+                       hover:bg-white/30 transition-colors border border-white/30"
+          >
+            Awesome!
+          </button>
+        </div>
+      </motion.div>
+    </motion.div>
+  )}
+</AnimatePresence>
+
+
 
       </div>
     </motion.div>

--- a/apps/frontend/src/pages/PlayPage.tsx
+++ b/apps/frontend/src/pages/PlayPage.tsx
@@ -22,10 +22,6 @@ function PlayPage() {
     displayDay,
     question,
     progress,
-    loading,
-    questionLoading,
-    attemptsInPeriod,
-    attemptsBeforeCooldown,
     cooldownSeconds,
     initialize,
     fetchQuestion,
@@ -44,7 +40,7 @@ function PlayPage() {
 
   const handleSelectDay = useCallback(async (day: number) => {
     const currentDay = getCurrentDay();
-    if (day > currentDay) return;
+    if (day > await currentDay) return;
     await fetchQuestion(day);
   }, [fetchQuestion]);
 
@@ -62,6 +58,8 @@ function PlayPage() {
       } else {
         setMessage(res.data?.result || 'Submitted');
         setAnswer('');
+
+        await fetchQuestion(displayDay);
       }
     } finally {
       setSubmitting(false);
@@ -162,7 +160,6 @@ function PlayPage() {
                 days={progress?.progress as any}
                 displayDay={displayDay}
                 onSelectDay={(d) => handleSelectDay(d)}
-                maxAccessibleDay={Math.min(getCurrentDay(), progress?.totalDays || getCurrentDay())}
               />
             </div>
 


### PR DESCRIPTION
Firestore Logic Updates

Added isDayUnlocked(day)
Validates if a day is accessible based on its Firestore unlockDate.
Added getUnlockedDays() for syncing the same logic of play page and leaderboard
![Uploading Screenshot from 2025-11-17 20-19-38.png…]()

Returns a list of all unlocked days to sync PlayPage + ProgressGrid control.
Preserved existing getCurrentDay() (Nov 17–22 window) for backward compatibility.
When Day 5 is completed, shows a polished congratulations msg popup.
Enhances user feedback and closes the challenge experience with a reward moment.