### PR TITLE
feat: Add loading percentage on top of rotating text

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,18 +1,20 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import AppRouter from "./router";
 import { LoadingScreen } from "./components/home/LoadingScreen";
 
 function App() {
   const [isLoading, setIsLoading] = useState(true);
 
-  useEffect(() => {
-    const timer = setTimeout(() => setIsLoading(false), 2500);
-    return () => clearTimeout(timer);
-  }, []);
-
   return (
     <>
-      {isLoading ? <LoadingScreen loadingDelay={2000} /> : <AppRouter />}
+      {isLoading ? (
+        <LoadingScreen
+          loadingDelay={3000}
+          onComplete={() => setIsLoading(false)}
+        />
+      ) : (
+        <AppRouter />
+      )}
     </>
   );
 }

--- a/apps/frontend/src/components/home/LoadingScreen.tsx
+++ b/apps/frontend/src/components/home/LoadingScreen.tsx
@@ -80,8 +80,10 @@ export const RotatingCanvasText: FC<RotatingCanvasTextProps> = ({
       const elapsed = now - start;
       const progress = Math.min(elapsed / duration, 1);
 
-      // Ease-Out cubic (slows down near end)
-      const eased = 1 - Math.pow(1 - progress, 3);
+      const eased =
+        progress < 0.5
+          ? 4 * progress * progress * progress
+          : 1 - Math.pow(-2 * progress + 2, 3) / 2;
 
       setPercent(Math.floor(eased * 100));
 

--- a/apps/frontend/src/components/home/LoadingScreen.tsx
+++ b/apps/frontend/src/components/home/LoadingScreen.tsx
@@ -1,14 +1,19 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type FC } from "react";
 
-import './home.css'
+import "./home.css";
 
 interface TypingTextProps {
   text: string;
   speed?: number;
 }
 
+interface RotatingCanvasTextProps {
+  duration?: number;
+}
+
 interface LoadingScreenProps {
   loadingDelay?: number;
+  onComplete: () => void;
 }
 
 export default function TypingText({ text, speed = 100 }: TypingTextProps) {
@@ -26,15 +31,17 @@ export default function TypingText({ text, speed = 100 }: TypingTextProps) {
   }, [text, speed]);
 
   return (
-    <h1 className="text-black font-bold font-whirlyBirdie text-9xl">
+    <h1 className="text-black font-bold font-whirlyBirdie text-5xl lg:text-9xl">
       {displayedText}
     </h1>
   );
 }
 
-
-const RotatingCanvasText = () => {
+export const RotatingCanvasText: FC<RotatingCanvasTextProps> = ({
+  duration = 0,
+}) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [percent, setPercent] = useState(0);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -66,23 +73,43 @@ const RotatingCanvasText = () => {
     }
   }, []);
 
+  useEffect(() => {
+    const start = performance.now();
+
+    const tick = (now: number) => {
+      const elapsed = now - start;
+      const progress = Math.min(elapsed / duration, 1);
+
+      // Ease-Out cubic (slows down near end)
+      const eased = 1 - Math.pow(1 - progress, 3);
+
+      setPercent(Math.floor(eased * 100));
+
+      if (progress < 1) requestAnimationFrame(tick);
+    };
+
+    requestAnimationFrame(tick);
+  }, [duration]);
+
   return (
-    <div className="relative flex items-center justify-center">
+    <div className="relative flex flex-col items-center justify-center">
+      {duration > 0 && (
+        <h1 className="font-whirlyBirdie text-4xl font-bold">{percent}%</h1>
+      )}
+
       <canvas ref={canvasRef} className="animate-spin-slow" />
 
-      <img
-        src="/enigma-logo.svg"
-        alt="logo"
-        className="absolute w-28 h-28"
-      />
+      <img src="/enigma-logo.svg" alt="logo" className="absolute w-28 h-28" />
     </div>
   );
 };
 
-export const LoadingScreen: React.FC<LoadingScreenProps> = ({ loadingDelay = 2000 }) => {
+export const LoadingScreen: React.FC<LoadingScreenProps> = ({
+  loadingDelay = 2000,
+  onComplete,
+}) => {
   const MAX_TYPING_TIME = 800;
   const typingDuration = Math.min(MAX_TYPING_TIME, loadingDelay);
-
   const rotatingDuration = loadingDelay - typingDuration;
 
   const [showTyping, setShowTyping] = useState(false);
@@ -90,20 +117,21 @@ export const LoadingScreen: React.FC<LoadingScreenProps> = ({ loadingDelay = 200
   useEffect(() => {
     const timer = setTimeout(() => {
       setShowTyping(true);
+
+      setTimeout(() => {
+        onComplete?.();
+      }, typingDuration + 100);
     }, rotatingDuration);
 
     return () => clearTimeout(timer);
-  }, [rotatingDuration]);
+  }, [rotatingDuration, typingDuration, onComplete]);
 
   return (
-    <section
-      id="loading-screen"
-      className="flex bg-[var(--background)] flex-1 min-h-screen min-w-max z-50 justify-center items-center"
-    >
+    <section className="flex bg-[var(--background)] min-h-screen justify-center items-center">
       {showTyping ? (
-        <TypingText text="ENIGMA" speed={typingDuration / 6} />
+        <TypingText text="ENIGMA" speed={typingDuration / 10} />
       ) : (
-        <RotatingCanvasText />
+        <RotatingCanvasText duration={rotatingDuration} />
       )}
     </section>
   );

--- a/apps/frontend/src/router.tsx
+++ b/apps/frontend/src/router.tsx
@@ -1,7 +1,8 @@
-import { lazy, Suspense } from 'react';
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { lazy, Suspense } from "react";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import ProtectedRoute from "./components/ProtectedRoute";
 import LandingLayout from "./components/LandingLayout";
+import { RotatingCanvasText } from "./components/home/LoadingScreen";
 
 // Lazy loaded pages
 const HomePage = lazy(() => import("./pages/HomePage"));
@@ -14,25 +15,22 @@ const HowItWorks = lazy(() => import("./pages/HowitWorks"));
 
 // Fallback loader
 const PageLoader = () => (
-  <div className="flex items-center justify-center min-h-screen text-white">
-    Loading...
+  <div className="flex min-h-screen justify-center items-center">
+    <RotatingCanvasText />
   </div>
 );
 
 function AppRouter() {
   const router = createBrowserRouter([
     {
-      path: '/',
-      element: (
-
-          <LandingLayout />
-      ),
+      path: "/",
+      element: <LandingLayout />,
       children: [
         // HOME
         {
           index: true,
           element: (
-            <Suspense fallback={<PageLoader />}>
+            <Suspense>
               <HomePage />
             </Suspense>
           ),
@@ -40,7 +38,7 @@ function AppRouter() {
 
         // ✅ NEW HOW IT WORKS PAGE
         {
-          path: '/how-it-works',
+          path: "/how-it-works",
           element: (
             <Suspense fallback={<PageLoader />}>
               <HowItWorks />
@@ -50,38 +48,38 @@ function AppRouter() {
 
         // RULES
         {
-          path: '/rules',
+          path: "/rules",
           element: (
             <Suspense fallback={<PageLoader />}>
               <Rules />
             </Suspense>
           ),
-          handle: { noScroll: true }
+          handle: { noScroll: true },
         },
 
         // ABOUT
         {
-          path: '/about-us',
+          path: "/about-us",
           element: (
             <Suspense fallback={<PageLoader />}>
               <AboutUs />
             </Suspense>
-          )
+          ),
         },
 
         // SIGN IN
         {
-          path: '/signin',
+          path: "/signin",
           element: (
             <Suspense fallback={<PageLoader />}>
               <SignInPage />
             </Suspense>
-          )
+          ),
         },
 
         // PLAY (Protected)
         {
-          path: '/play',
+          path: "/play",
           element: (
             <ProtectedRoute>
               <Suspense fallback={<PageLoader />}>
@@ -93,7 +91,7 @@ function AppRouter() {
 
         // LEADERBOARD (Protected)
         {
-          path: '/leaderboard',
+          path: "/leaderboard",
           element: (
             <ProtectedRoute>
               <Suspense fallback={<PageLoader />}>


### PR DESCRIPTION
PR Sumary:
- Add a percentage above rotating text and properly integrate it with loading
<img width="300" height="auto" alt="Screenshot 2025-12-08 at 3 31 52 PM" src="https://github.com/user-attachments/assets/63480288-32c6-410c-9763-dfa2146bb3a6" />
