### PR TITLE
Refactor: split hero parallax tiles into dedicated components

### DIFF
--- a/apps/frontend/src/components/HeroSection.tsx
+++ b/apps/frontend/src/components/HeroSection.tsx
@@ -1,166 +1,45 @@
-import { useEffect, useState } from "react";
-import { motion, useMotionValue, useTransform, MotionValue } from "framer-motion";
+import React, { useEffect, useState } from "react";
+import { motion, useMotionValue, useTransform } from "framer-motion";
 import { Link } from "react-router-dom";
 import { cn } from "../lib/utils";
 import { useAuth } from "../contexts/AuthContext";
 import Footer from "./ui/footer";
+import HowItWorksSection from "./hero/Howitworks";
 
-import p1 from "@/assets/p1.webp";
-import p2 from "@/assets/p2.webp";
-import p3 from "@/assets/p3.webp";
-import p4 from "@/assets/p4.webp";
-import p5 from "@/assets/p5.webp";
-import p6 from "@/assets/p6.webp";
-import p7 from "@/assets/p7.webp";
-import p8 from "@/assets/p8.webp";
-import p9 from "@/assets/p9.webp";
-import p10 from "@/assets/p10.webp";
-import p11 from "@/assets/p11.webp";
-import p12 from "@/assets/p12.webp";
-import p13 from "@/assets/p13.webp";
-import p14 from "@/assets/p14.webp";
-import p15 from "@/assets/p15.webp";
-import p16 from "@/assets/p16.webp";
+import HeroTile1 from "./hero/tiles/HeroTile1";
+import HeroTile2 from "./hero/tiles/HeroTile2";
+import HeroTile3 from "./hero/tiles/HeroTile3";
+import HeroTile4 from "./hero/tiles/HeroTile4";
+import HeroTile5 from "./hero/tiles/HeroTile5";
+import HeroTile6 from "./hero/tiles/HeroTile6";
+import HeroTile7 from "./hero/tiles/HeroTile7";
+import HeroTile8 from "./hero/tiles/HeroTile8";
+import HeroTile9 from "./hero/tiles/HeroTile9";
+import HeroTile10 from "./hero/tiles/HeroTile10";
+import HeroTile11 from "./hero/tiles/HeroTile11";
+import HeroTile12 from "./hero/tiles/HeroTile12";
+import HeroTile13 from "./hero/tiles/HeroTile13";
+import HeroTile14 from "./hero/tiles/HeroTile14";
+import HeroTile15 from "./hero/tiles/HeroTile15";
+import HeroTile16 from "./hero/tiles/HeroTile16";
 
-const steps = [
-  { id: 1, number: "01", title: "REGISTER", description: "Create an account or sign in with Google" },
-  { id: 2, number: "02", title: "DAILY QUESTION", description: "Answer today's challenge as quickly as possible" },
-  { id: 3, number: "03", title: "COMPETE", description: "See your ranking on the daily leaderboard" },
-  { id: 4, number: "04", title: "REPEAT", description: "Come back tomorrow for the next challenge!" }
-];
-
-const tilesContainerVariants = {
-  hidden: { opacity: 0, y: 12 },
-  visible: { opacity: 1, y: 0, transition: { staggerChildren: 0.18, when: "beforeChildren" } }
+const containerVariants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.25 } }
 };
 
-const tileVariants = {
-  hidden: { opacity: 0, y: 8 },
-  visible: { opacity: 1, y: 0, transition: { duration: 0.9, ease: "easeOut" } }
+const fadeUp = {
+  hidden: { opacity: 0, y: 40 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.9 } }
 };
 
-const HowItWorksSection = () => {
-  return (
-    <section id="how-it-works-section" className="pt-24 pb-32 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-6xl mx-auto">
-        <h2
-          style={{ fontFamily: "WhirlyBirdie" }}
-          className="text-4xl md:text-5xl font-bold text-black text-center mb-6"
-        >
-          HOW IT WORKS
-        </h2>
-
-        <div className="text-center max-w-3xl mx-auto mb-12">
-          <p className="text-2xl md:text-3xl font-bold text-black/90">
-            Join our 10-day treasure hunt!!
-          </p>
-          <p className="text-md md:text-lg font-bold text-black/70 mt-4">
-            One question per day, compete for the fastest completion time, and climb the daily leaderboard
-          </p>
-        </div>
-
-        <motion.div
-          className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6"
-          variants={tilesContainerVariants}
-          initial="hidden"
-          animate="visible"
-        >
-          {steps.map((step) => (
-            <motion.div
-              key={step.id}
-              variants={tileVariants}
-              className="group relative bg-black border-[3px] border-white text-white overflow-hidden cursor-pointer flex items-center justify-center min-h-[16rem]"
-              tabIndex={0}
-            >
-              <div className="relative z-10 flex flex-col items-center justify-center text-center px-4 py-6 w-full h-full">
-                <div
-                  style={{ fontFamily: "WhirlyBirdie", fontSize: "32px" }}
-                  className="font-bold mb-2"
-                >
-                  {step.number}
-                </div>
-
-                <div
-                  style={{ fontFamily: "WhirlyBirdie", fontSize: "18px" }}
-                  className="font-bold mb-3"
-                >
-                  {step.title}
-                </div>
-
-                <p
-                  className={
-                    "text-sm md:text-base text-white/90 max-w-[160px] mx-auto transition-all duration-700 opacity-0 translate-y-4 " +
-                    "group-hover:opacity-100 group-hover:translate-y-0 group-focus:opacity-100 group-focus:translate-y-0"
-                  }
-                >
-                  {step.description}
-                </p>
-              </div>
-
-              <div aria-hidden className="pointer-events-none absolute inset-0 border-[3px] border-white" />
-            </motion.div>
-          ))}
-        </motion.div>
-      </div>
-    </section>
-  );
-};
-
-type TileConfig = {
-  id: string;
-  src: string;
-  depth: number;
-  ox: number;
-  oy: number;
-  size: string;
-};
-
-type ParallaxTileProps = {
-  tile: TileConfig;
-  smoothX: MotionValue<number>;
-  smoothY: MotionValue<number>;
-  viewportWidth: number;
-  viewportHeight: number;
-  parallax: number;
-};
-
-const ParallaxTile = ({
-  tile,
-  smoothX,
-  smoothY,
-  viewportWidth,
-  viewportHeight,
-  parallax
-}: ParallaxTileProps) => {
-  const x = useTransform(smoothX, (v) => {
-    const baseX = tile.ox * (viewportWidth / 2);
-    return baseX + -v * tile.depth * viewportWidth * parallax;
-  });
-
-  const y = useTransform(smoothY, (v) => {
-    const baseY = tile.oy * (viewportHeight / 2);
-    return baseY + -v * tile.depth * viewportHeight * parallax;
-  });
-
-  return (
-    <motion.div
-      className={cn(
-        "absolute left-1/2 top-1/2 rounded-2xl shadow-xl overflow-hidden pointer-events-none",
-        tile.size
-      )}
-      style={{ x, y }}
-    >
-      <img src={tile.src} className="h-full w-full object-cover" draggable={false} />
-    </motion.div>
-  );
+const fadeIn = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { duration: 0.9 } }
 };
 
 const HeroSection = () => {
   const { currentUser } = useAuth();
-
-  const containerVariants = { hidden: {}, visible: { transition: { staggerChildren: 0.25 } } };
-  const fadeUp = { hidden: { opacity: 0, y: 40 }, visible: { opacity: 1, y: 0, transition: { duration: 0.9 } } };
-  const fadeIn = { hidden: { opacity: 0 }, visible: { opacity: 1, transition: { duration: 0.9 } } };
 
   const [vp, setVp] = useState({ w: 0, h: 0 });
 
@@ -178,6 +57,7 @@ const HeroSection = () => {
 
   const { w, h } = vp;
 
+  // Mouse position → normalized target values (-1 to 1)
   useEffect(() => {
     const move = (e: MouseEvent) => {
       if (!w || !h) return;
@@ -191,6 +71,7 @@ const HeroSection = () => {
     return () => window.removeEventListener("mousemove", move);
   }, [w, h, targetX, targetY]);
 
+  // Smooth lag pointer and parallax driver
   useEffect(() => {
     let frame: number;
     const animate = () => {
@@ -214,25 +95,6 @@ const HeroSection = () => {
 
   const pointerX = useTransform(smoothX, (v) => v * (w / 2));
   const pointerY = useTransform(smoothY, (v) => v * (h / 2));
-
-  const tiles: TileConfig[] = [
-    { id: "1", src: p1, depth: 0.7, ox: -1.8, oy: -1.6, size: "w-[16%]" },
-    { id: "2", src: p2, depth: 0.7, ox: -1.2, oy: -1.4, size: "w-[16%]" },
-    { id: "3", src: p3, depth: 0.7, ox: 1.2, oy: -1.4, size: "w-[16%]" },
-    { id: "4", src: p4, depth: 0.7, ox: 1.8, oy: -1.6, size: "w-[16%]" },
-    { id: "5", src: p5, depth: 0.8, ox: -2.0, oy: -0.5, size: "w-[18%]" },
-    { id: "6", src: p6, depth: 0.8, ox: 1.7, oy: 0.0, size: "w-[18%]" },
-    { id: "7", src: p7, depth: 0.8, ox: -2.0, oy: 0.7, size: "w-[18%]" },
-    { id: "8", src: p8, depth: 0.8, ox: 1.6, oy: 0.9, size: "w-[18%]" },
-    { id: "9", src: p9, depth: 0.6, ox: -0.35, oy: -1.1, size: "w-[15%]" },
-    { id: "10", src: p10, depth: 0.6, ox: 0.35, oy: -1.1, size: "w-[15%]" },
-    { id: "11", src: p11, depth: 0.6, ox: -0.35, oy: 1.1, size: "w-[15%]" },
-    { id: "12", src: p12, depth: 0.6, ox: 0.35, oy: 0.95, size: "w-[15%]" },
-    { id: "13", src: p13, depth: 0.7, ox: -1.45, oy: 1.4, size: "w-[17%]" },
-    { id: "14", src: p14, depth: 0.7, ox: 1.2, oy: 1.4, size: "w-[17%]" },
-    { id: "15", src: p15, depth: 0.45, ox: -0.7, oy: 0.02, size: "w-[14%]" },
-    { id: "16", src: p16, depth: 0.45, ox: 0.55, oy: -0.05, size: "w-[14%]" }
-  ];
 
   const scrollToHow = () => {
     const el = document.getElementById("how-it-works-section");
@@ -262,18 +124,24 @@ const HeroSection = () => {
                 mass: 0.4
               }}
             />
+
             <div className="pointer-events-none absolute inset-0 z-10">
-              {tiles.map((tile) => (
-                <ParallaxTile
-                  key={tile.id}
-                  tile={tile}
-                  smoothX={smoothX}
-                  smoothY={smoothY}
-                  viewportWidth={w}
-                  viewportHeight={h}
-                  parallax={parallax}
-                />
-              ))}
+              <HeroTile1 smoothX={smoothX} smoothY={smoothY} viewportWidth={w} viewportHeight={h} parallax={parallax} />
+              <HeroTile2 smoothX={smoothX} smoothY={smoothY} viewportWidth={w} viewportHeight={h} parallax={parallax} />
+              <HeroTile3 smoothX={smoothX} smoothY={smoothY} viewportWidth={w} viewportHeight={h} parallax={parallax} />
+              <HeroTile4 smoothX={smoothX} smoothY={smoothY} viewportWidth={w} viewportHeight={h} parallax={parallax} />
+              <HeroTile5 smoothX={smoothX} smoothY={smoothY} viewportWidth={w} viewportHeight={h} parallax={parallax} />
+              <HeroTile6 smoothX={smoothX} smoothY={smoothY} viewportWidth={w} viewportHeight={h} parallax={parallax} />
+              <HeroTile7 smoothX={smoothX} smoothY={smoothY} viewportWidth={w} viewportHeight={h} parallax={parallax} />
+              <HeroTile8 smoothX={smoothX} smoothY={smoothY} viewportWidth={w} viewportHeight={h} parallax={parallax} />
+              <HeroTile9 smoothX={smoothX} smoothY={smoothY} viewportWidth={w} viewportHeight={h} parallax={parallax} />
+              <HeroTile10 smoothX={smoothX} smoothY={smoothY} viewportWidth={w} viewportHeight={h} parallax={parallax} />
+              <HeroTile11 smoothX={smoothX} smoothY={smoothY} viewportWidth={w} viewportHeight={h} parallax={parallax} />
+              <HeroTile12 smoothX={smoothX} smoothY={smoothY} viewportWidth={w} viewportHeight={h} parallax={parallax} />
+              <HeroTile13 smoothX={smoothX} smoothY={smoothY} viewportWidth={w} viewportHeight={h} parallax={parallax} />
+              <HeroTile14 smoothX={smoothX} smoothY={smoothY} viewportWidth={w} viewportHeight={h} parallax={parallax} />
+              <HeroTile15 smoothX={smoothX} smoothY={smoothY} viewportWidth={w} viewportHeight={h} parallax={parallax} />
+              <HeroTile16 smoothX={smoothX} smoothY={smoothY} viewportWidth={w} viewportHeight={h} parallax={parallax} />
             </div>
           </>
         )}

--- a/apps/frontend/src/components/hero/Howitworks.tsx
+++ b/apps/frontend/src/components/hero/Howitworks.tsx
@@ -1,0 +1,87 @@
+import { motion } from "framer-motion";
+
+const steps = [
+  { id: 1, number: "01", title: "REGISTER", description: "Create an account or sign in with Google" },
+  { id: 2, number: "02", title: "DAILY QUESTION", description: "Answer today's challenge as quickly as possible" },
+  { id: 3, number: "03", title: "COMPETE", description: "See your ranking on the daily leaderboard" },
+  { id: 4, number: "04", title: "REPEAT", description: "Come back tomorrow for the next challenge!" }
+];
+
+const tilesContainerVariants = {
+  hidden: { opacity: 0, y: 12 },
+  visible: { opacity: 1, y: 0, transition: { staggerChildren: 0.18, when: "beforeChildren" } }
+};
+
+const tileVariants = {
+  hidden: { opacity: 0, y: 8 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.9, ease: "easeOut" } }
+};
+
+const HowItWorksSection = () => {
+  return (
+    <section id="how-it-works-section" className="pt-24 pb-32 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-6xl mx-auto">
+        <h2
+          style={{ fontFamily: "WhirlyBirdie" }}
+          className="text-4xl md:text-5xl font-bold text-black text-center mb-6"
+        >
+          HOW IT WORKS
+        </h2>
+
+        <div className="text-center max-w-3xl mx-auto mb-12">
+          <p className="text-2xl md:text-3xl font-bold text-black/90">
+            Join our 10-day treasure hunt!!
+          </p>
+          <p className="text-md md:text-lg font-bold text-black/70 mt-4">
+            One question per day, compete for the fastest completion time, and climb the daily leaderboard
+          </p>
+        </div>
+
+        <motion.div
+          className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6"
+          variants={tilesContainerVariants}
+          initial="hidden"
+          animate="visible"
+        >
+          {steps.map((step) => (
+            <motion.div
+              key={step.id}
+              variants={tileVariants}
+              className="group relative bg-black border-[3px] border-white text-white overflow-hidden cursor-pointer flex items-center justify-center min-h-[16rem]"
+              tabIndex={0}
+            >
+              <div className="relative z-10 flex flex-col items-center justify-center text-center px-4 py-6 w-full h-full">
+                <div
+                  style={{ fontFamily: "WhirlyBirdie", fontSize: "32px" }}
+                  className="font-bold mb-2"
+                >
+                  {step.number}
+                </div>
+
+                <div
+                  style={{ fontFamily: "WhirlyBirdie", fontSize: "18px" }}
+                  className="font-bold mb-3"
+                >
+                  {step.title}
+                </div>
+
+                <p
+                  className={
+                    "text-sm md:text-base text-white/90 max-w-[160px] mx-auto transition-all duration-700 opacity-0 translate-y-4 " +
+                    "group-hover:opacity-100 group-hover:translate-y-0 group-focus:opacity-100 group-focus:translate-y-0"
+                  }
+                >
+                  {step.description}
+                </p>
+              </div>
+
+              <div aria-hidden className="pointer-events-none absolute inset-0 border-[3px] border-white" />
+            </motion.div>
+          ))}
+        </motion.div>
+      </div>
+    </section>
+  );
+};
+
+export default HowItWorksSection;

--- a/apps/frontend/src/components/hero/ParallaxTile.tsx
+++ b/apps/frontend/src/components/hero/ParallaxTile.tsx
@@ -1,0 +1,53 @@
+import { motion, useTransform, MotionValue } from "framer-motion";
+import { cn } from "@/lib/utils";
+
+type ParallaxTileProps = {
+  smoothX: MotionValue<number>;
+  smoothY: MotionValue<number>;
+  viewportWidth: number;
+  viewportHeight: number;
+  parallax: number;
+  depth: number;
+  ox: number;
+  oy: number;
+  sizeClass: string;
+  src: string;
+};
+
+const ParallaxTile = ({
+  smoothX,
+  smoothY,
+  viewportWidth,
+  viewportHeight,
+  parallax,
+  depth,
+  ox,
+  oy,
+  sizeClass,
+  src
+}: ParallaxTileProps) => {
+  const x = useTransform(smoothX, (v) => {
+    const baseX = ox * (viewportWidth / 2);
+    return baseX + -v * depth * viewportWidth * parallax;
+  });
+
+  const y = useTransform(smoothY, (v) => {
+    const baseY = oy * (viewportHeight / 2);
+    return baseY + -v * depth * viewportHeight * parallax;
+  });
+
+  return (
+    <motion.div
+      className={cn(
+        "absolute left-1/2 top-1/2 rounded-2xl shadow-xl overflow-hidden pointer-events-none",
+        sizeClass
+      )}
+      style={{ x, y }}
+    >
+      <img src={src} className="h-full w-full object-cover" draggable={false} />
+    </motion.div>
+  );
+};
+
+export type { ParallaxTileProps };
+export default ParallaxTile;

--- a/apps/frontend/src/components/hero/tiles/HeroTile1.tsx
+++ b/apps/frontend/src/components/hero/tiles/HeroTile1.tsx
@@ -1,0 +1,18 @@
+import type { ParallaxTileProps } from "../ParallaxTile";
+import ParallaxTile from "../ParallaxTile";
+import p2 from "@/assets/p1.webp";
+
+type Props = Omit<ParallaxTileProps, "depth" | "ox" | "oy" | "sizeClass" | "src">;
+
+const HeroTile2 = (props: Props) => (
+  <ParallaxTile
+    {...props}
+    depth={0.7}
+    ox={-1.2}
+    oy={-1.4}
+    sizeClass="w-[16%]"
+    src={p2}
+  />
+);
+
+export default HeroTile2;

--- a/apps/frontend/src/components/hero/tiles/HeroTile10.tsx
+++ b/apps/frontend/src/components/hero/tiles/HeroTile10.tsx
@@ -1,0 +1,18 @@
+import type { ParallaxTileProps } from "../ParallaxTile";
+import ParallaxTile from "../ParallaxTile";
+import p10 from "@/assets/p10.webp";
+
+type Props = Omit<ParallaxTileProps, "depth" | "ox" | "oy" | "sizeClass" | "src">;
+
+const HeroTile10 = (props: Props) => (
+  <ParallaxTile
+    {...props}
+    depth={0.6}
+    ox={0.35}
+    oy={-1.1}
+    sizeClass="w-[15%]"
+    src={p10}
+  />
+);
+
+export default HeroTile10;

--- a/apps/frontend/src/components/hero/tiles/HeroTile11.tsx
+++ b/apps/frontend/src/components/hero/tiles/HeroTile11.tsx
@@ -1,0 +1,18 @@
+import type { ParallaxTileProps } from "../ParallaxTile";
+import ParallaxTile from "../ParallaxTile";
+import p11 from "@/assets/p11.webp";
+
+type Props = Omit<ParallaxTileProps, "depth" | "ox" | "oy" | "sizeClass" | "src">;
+
+const HeroTile11 = (props: Props) => (
+  <ParallaxTile
+    {...props}
+    depth={0.6}
+    ox={-0.35}
+    oy={1.1}
+    sizeClass="w-[15%]"
+    src={p11}
+  />
+);
+
+export default HeroTile11;

--- a/apps/frontend/src/components/hero/tiles/HeroTile12.tsx
+++ b/apps/frontend/src/components/hero/tiles/HeroTile12.tsx
@@ -1,0 +1,18 @@
+import type { ParallaxTileProps } from "../ParallaxTile";
+import ParallaxTile from "../ParallaxTile";
+import p12 from "@/assets/p12.webp";
+
+type Props = Omit<ParallaxTileProps, "depth" | "ox" | "oy" | "sizeClass" | "src">;
+
+const HeroTile12 = (props: Props) => (
+  <ParallaxTile
+    {...props}
+    depth={0.6}
+    ox={0.35}
+    oy={0.95}
+    sizeClass="w-[15%]"
+    src={p12}
+  />
+);
+
+export default HeroTile12;

--- a/apps/frontend/src/components/hero/tiles/HeroTile13.tsx
+++ b/apps/frontend/src/components/hero/tiles/HeroTile13.tsx
@@ -1,0 +1,18 @@
+import type{ ParallaxTileProps } from "../ParallaxTile";
+import ParallaxTile from "../ParallaxTile";
+import p13 from "@/assets/p13.webp";
+
+type Props = Omit<ParallaxTileProps, "depth" | "ox" | "oy" | "sizeClass" | "src">;
+
+const HeroTile13 = (props: Props) => (
+  <ParallaxTile
+    {...props}
+    depth={0.7}
+    ox={-1.45}
+    oy={1.4}
+    sizeClass="w-[17%]"
+    src={p13}
+  />
+);
+
+export default HeroTile13;

--- a/apps/frontend/src/components/hero/tiles/HeroTile14.tsx
+++ b/apps/frontend/src/components/hero/tiles/HeroTile14.tsx
@@ -1,0 +1,18 @@
+import type{ ParallaxTileProps } from "../ParallaxTile";
+import ParallaxTile from "../ParallaxTile";
+import p14 from "@/assets/p14.webp";
+
+type Props = Omit<ParallaxTileProps, "depth" | "ox" | "oy" | "sizeClass" | "src">;
+
+const HeroTile14 = (props: Props) => (
+  <ParallaxTile
+    {...props}
+    depth={0.7}
+    ox={1.2}
+    oy={1.4}
+    sizeClass="w-[17%]"
+    src={p14}
+  />
+);
+
+export default HeroTile14;

--- a/apps/frontend/src/components/hero/tiles/HeroTile15.tsx
+++ b/apps/frontend/src/components/hero/tiles/HeroTile15.tsx
@@ -1,0 +1,18 @@
+import type{ ParallaxTileProps } from "../ParallaxTile";
+import ParallaxTile from "../ParallaxTile";
+import p15 from "@/assets/p15.webp";
+
+type Props = Omit<ParallaxTileProps, "depth" | "ox" | "oy" | "sizeClass" | "src">;
+
+const HeroTile15 = (props: Props) => (
+  <ParallaxTile
+    {...props}
+    depth={0.45}
+    ox={-0.7}
+    oy={0.02}
+    sizeClass="w-[14%]"
+    src={p15}
+  />
+);
+
+export default HeroTile15;

--- a/apps/frontend/src/components/hero/tiles/HeroTile16.tsx
+++ b/apps/frontend/src/components/hero/tiles/HeroTile16.tsx
@@ -1,0 +1,18 @@
+import type{ ParallaxTileProps } from "../ParallaxTile";
+import ParallaxTile from "../ParallaxTile";
+import p16 from "@/assets/p16.webp";
+
+type Props = Omit<ParallaxTileProps, "depth" | "ox" | "oy" | "sizeClass" | "src">;
+
+const HeroTile16 = (props: Props) => (
+  <ParallaxTile
+    {...props}
+    depth={0.45}
+    ox={0.55}
+    oy={-0.05}
+    sizeClass="w-[14%]"
+    src={p16}
+  />
+);
+
+export default HeroTile16;

--- a/apps/frontend/src/components/hero/tiles/HeroTile2.tsx
+++ b/apps/frontend/src/components/hero/tiles/HeroTile2.tsx
@@ -1,0 +1,18 @@
+import type { ParallaxTileProps } from "../ParallaxTile";
+import ParallaxTile from "../ParallaxTile";
+import p2 from "@/assets/p2.webp";
+
+type Props = Omit<ParallaxTileProps, "depth" | "ox" | "oy" | "sizeClass" | "src">;
+
+const HeroTile2 = (props: Props) => (
+  <ParallaxTile
+    {...props}
+    depth={0.7}
+    ox={-1.2}
+    oy={-1.4}
+    sizeClass="w-[16%]"
+    src={p2}
+  />
+);
+
+export default HeroTile2;

--- a/apps/frontend/src/components/hero/tiles/HeroTile3.tsx
+++ b/apps/frontend/src/components/hero/tiles/HeroTile3.tsx
@@ -1,0 +1,18 @@
+import type  { ParallaxTileProps } from "../ParallaxTile";
+import ParallaxTile from "../ParallaxTile";
+import p3 from "@/assets/p3.webp";
+
+type Props = Omit<ParallaxTileProps, "depth" | "ox" | "oy" | "sizeClass" | "src">;
+
+const HeroTile3 = (props: Props) => (
+  <ParallaxTile
+    {...props}
+    depth={0.7}
+    ox={1.2}
+    oy={-1.4}
+    sizeClass="w-[16%]"
+    src={p3}
+  />
+);
+
+export default HeroTile3;

--- a/apps/frontend/src/components/hero/tiles/HeroTile4.tsx
+++ b/apps/frontend/src/components/hero/tiles/HeroTile4.tsx
@@ -1,0 +1,18 @@
+import type { ParallaxTileProps } from "../ParallaxTile";
+import ParallaxTile from "../ParallaxTile";
+import p4 from "@/assets/p4.webp";
+
+type Props = Omit<ParallaxTileProps, "depth" | "ox" | "oy" | "sizeClass" | "src">;
+
+const HeroTile4 = (props: Props) => (
+  <ParallaxTile
+    {...props}
+    depth={0.7}
+    ox={1.8}
+    oy={-1.6}
+    sizeClass="w-[16%]"
+    src={p4}
+  />
+);
+
+export default HeroTile4;

--- a/apps/frontend/src/components/hero/tiles/HeroTile5.tsx
+++ b/apps/frontend/src/components/hero/tiles/HeroTile5.tsx
@@ -1,0 +1,18 @@
+import type { ParallaxTileProps } from "../ParallaxTile";
+import ParallaxTile from "../ParallaxTile";
+import p5 from "@/assets/p5.webp";
+
+type Props = Omit<ParallaxTileProps, "depth" | "ox" | "oy" | "sizeClass" | "src">;
+
+const HeroTile5 = (props: Props) => (
+  <ParallaxTile
+    {...props}
+    depth={0.8}
+    ox={-2.0}
+    oy={-0.5}
+    sizeClass="w-[18%]"
+    src={p5}
+  />
+);
+
+export default HeroTile5;

--- a/apps/frontend/src/components/hero/tiles/HeroTile6.tsx
+++ b/apps/frontend/src/components/hero/tiles/HeroTile6.tsx
@@ -1,0 +1,18 @@
+import type { ParallaxTileProps } from "../ParallaxTile";
+import ParallaxTile from "../ParallaxTile";
+import p6 from "@/assets/p6.webp";
+
+type Props = Omit<ParallaxTileProps, "depth" | "ox" | "oy" | "sizeClass" | "src">;
+
+const HeroTile6 = (props: Props) => (
+  <ParallaxTile
+    {...props}
+    depth={0.8}
+    ox={1.7}
+    oy={0.0}
+    sizeClass="w-[18%]"
+    src={p6}
+  />
+);
+
+export default HeroTile6;

--- a/apps/frontend/src/components/hero/tiles/HeroTile7.tsx
+++ b/apps/frontend/src/components/hero/tiles/HeroTile7.tsx
@@ -1,0 +1,18 @@
+import type { ParallaxTileProps } from "../ParallaxTile";
+import ParallaxTile from "../ParallaxTile";
+import p7 from "@/assets/p7.webp";
+
+type Props = Omit<ParallaxTileProps, "depth" | "ox" | "oy" | "sizeClass" | "src">;
+
+const HeroTile7 = (props: Props) => (
+  <ParallaxTile
+    {...props}
+    depth={0.8}
+    ox={-2.0}
+    oy={0.7}
+    sizeClass="w-[18%]"
+    src={p7}
+  />
+);
+
+export default HeroTile7;

--- a/apps/frontend/src/components/hero/tiles/HeroTile8.tsx
+++ b/apps/frontend/src/components/hero/tiles/HeroTile8.tsx
@@ -1,0 +1,18 @@
+import type { ParallaxTileProps } from "../ParallaxTile";
+import ParallaxTile from "../ParallaxTile";
+import p8 from "@/assets/p8.webp";
+
+type Props = Omit<ParallaxTileProps, "depth" | "ox" | "oy" | "sizeClass" | "src">;
+
+const HeroTile8 = (props: Props) => (
+  <ParallaxTile
+    {...props}
+    depth={0.8}
+    ox={1.6}
+    oy={0.9}
+    sizeClass="w-[18%]"
+    src={p8}
+  />
+);
+
+export default HeroTile8;

--- a/apps/frontend/src/components/hero/tiles/HeroTile9.tsx
+++ b/apps/frontend/src/components/hero/tiles/HeroTile9.tsx
@@ -1,0 +1,18 @@
+import type { ParallaxTileProps } from "../ParallaxTile";
+import ParallaxTile from "../ParallaxTile";
+import p9 from "@/assets/p9.webp";
+
+type Props = Omit<ParallaxTileProps, "depth" | "ox" | "oy" | "sizeClass" | "src">;
+
+const HeroTile9 = (props: Props) => (
+  <ParallaxTile
+    {...props}
+    depth={0.6}
+    ox={-0.35}
+    oy={-1.1}
+    sizeClass="w-[15%]"
+    src={p9}
+  />
+);
+
+export default HeroTile9;

--- a/apps/frontend/src/pages/Rules.tsx
+++ b/apps/frontend/src/pages/Rules.tsx
@@ -58,7 +58,7 @@ const Rules = () => {
       <div className="hidden lg:block">
         <div className="absolute bg-black" style={{ width: `${LAYOUT.desktop.headerWidth}px`, height: `${LAYOUT.desktop.headerHeight}px`, left: `${LAYOUT.desktop.headerLeft}px`, top: `${LAYOUT.desktop.headerTop}px` }} />
         <div className="absolute text-white font-whirly font-bold" style={{ width: "130px", height: "29px", left: "60.01px", top: "157px", fontSize: "24px", lineHeight: "29px" }}>RULES</div>
-        <div className="absolute font-whirly font-bold text-center" style={{ width: "370px", height: "43px", left: "calc(50% - 370px/2)", top: "293px", fontSize: "36px", lineHeight: "43px", letterSpacing: "-0.02em", color: "#000000" }}>game rules</div>
+        <div className="absolute font-whirly font-bold text-center" style={{ width: "370px", height: "43px", left: "calc(50% - 370px/2)", top: "293px", fontSize: "36px", lineHeight: "43px", letterSpacing: "-0.02em", color: "#000000" }}>GAME RULES</div>
         <div className="absolute font-poppins font-medium text-center flex items-center" style={{ width: "651px", height: "62px", left: "calc(50% - 651px/2 + 0.5px)", top: "334px", fontSize: "24px", lineHeight: "62px", letterSpacing: "0.01em", color: "#000000" }}>Master the challenge with these essential guidelines</div>
         {RULES.map((rule, index) => <RuleFrame key={index} rule={rule} index={index} isMobile={false} />)}
       </div>


### PR DESCRIPTION


# 🔧 **PR Title**

**refactor: split hero parallax tiles into dedicated components**

---

# 📌 **Summary**

This PR restructures the HeroSection by extracting all 16 parallax tile images into individual components, each powered by a shared base `ParallaxTile` component. The HeroSection now imports these tiles directly, improving clarity, modularity, and long-term maintainability. The `HowItWorksSection` has also been moved to its own file for cleaner separation.

---

# 📄 **Changes**

### **Refactor**

* Added shared `ParallaxTile` base component.
* Split each hero background tile into its own component (`HeroTile1`–`HeroTile16`).
* Updated `HeroSection` to use the new component-based tile structure.
* Moved `HowItWorksSection` into a dedicated standalone file.

### **Behavior**

* No logic changes to parallax movement.
* UI and animations remain identical to before the refactor.
* No global CSS or backend modifications.

---


