### PR TITLE
feat: implement gray tile style for locked levels

### DIFF
--- a/apps/frontend/src/components/dayMap/dayTile.tsx
+++ b/apps/frontend/src/components/dayMap/dayTile.tsx
@@ -16,16 +16,20 @@ export const DayTile = ({
     if (isDayAccessible && !isComplete) navigate(`/play/${day}`);
   };
 
+  const isLocked = !isComplete && !isDayAccessible;
+
   return (
     <div
-      className={`group overflow-visible day-cell w-full h-full px-2 bg-black text-white flex items-center justify-center text-base font-whirlyBirdie font-bold border border-white/20 ${
-        isComplete ? "day-complete" : isDayAccessible && "day-hoverable"
-      }`}
+      className={`group overflow-visible day-cell w-full h-full px-2 flex items-center justify-center text-base font-whirlyBirdie font-bold border ${isLocked
+          ? "bg-[#252525] text-white/30 border-white/10" // Gray/Dimmed for Locked
+          : "bg-black text-white border-white/20"        // Black/Bright for Accessible/Complete
+        } ${isComplete ? "day-complete" : isDayAccessible ? "day-hoverable" : ""
+        }`}
       onClick={handleClick}
     >
-      <div className="day-cell-side overflow-visible" />
+      <div className={`day-cell-side overflow-visible ${isLocked ? "!bg-[#1a1a1a]" : ""}`} />
       DAY {day}
-      <div className="day-cell-bottom overflow-visible" />
+      <div className={`day-cell-bottom overflow-visible ${isLocked ? "!bg-[#1a1a1a]" : ""}`} />
     </div>
   );
 };


### PR DESCRIPTION
- **Implement Gray Tile for Locked Levels**
  - Added a distinct visual state for levels that are "locked" (not yet accessible).
  - Locked tiles now render with a dark gray background (`#252525`) and matching 3D sides (`#1a1a1a`).
  - Adjusted text opacity for locked tiles to indicate inactivity.
## 🛠️ Changes
- **Modified [dayTile.tsx]**:
  - Introduced `isLocked` logic to determine styling.
  - Applied conditional Tailwind classes to override the default black theme when a level is locked.
## 📸 Screenshots
<img width="1871" height="882" alt="image" src="https://github.com/user-attachments/assets/4bdaac55-f09c-4a4d-89eb-9acf351050db" />
