### PR TITLE
Make Play page progress dynamic and refine scroll/UX across pages

### DIFF
--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -48,3 +48,40 @@
 .animate-spin-slow {
   animation: spin-slow 16s linear infinite;
 }
+
+/* Scrollbar styling for internal progress panel on Play page */
+.internal-progress-scroll {
+  /* Thin scrollbar: black thumb over white track so the scrollbar itself
+     looks like a white vertical bar with a black handle. */
+  scrollbar-width: thin;
+  scrollbar-color: #000000 #ffffff; /* thumb = black, track = white */
+}
+
+.internal-progress-scroll::-webkit-scrollbar {
+  width: 12px;
+}
+
+.internal-progress-scroll::-webkit-scrollbar-track {
+  background: #ffffff; /* white track */
+}
+
+.internal-progress-scroll::-webkit-scrollbar-thumb {
+  background-color: #000000;
+  border-radius: 0;
+}
+
+/* Hide scrollbar arrows/buttons inside the internal progress scrollbar */
+.internal-progress-scroll::-webkit-scrollbar-button {
+  height: 0;
+  width: 0;
+  background: transparent;
+  display: none;
+}
+
+/* Extra guard for some WebKit implementations (top/bottom single buttons) */
+.internal-progress-scroll::-webkit-scrollbar-button:single-button {
+  height: 0;
+  width: 0;
+  background: transparent;
+  display: none;
+}

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -13,10 +13,25 @@
   --primary:white;
 }
 
-/* Allow normal page scrolling again */
+/* Allow normal page scrolling by default */
 html, body {
   height: auto;
   overflow: auto;
+}
+
+/* Hide main page scrollbar visually (used on specific pages like Rules).
+   We target both html and body because different browsers attach the main
+   scrollbar to different roots. */
+html.no-main-scrollbar,
+body.no-main-scrollbar {
+  /* Firefox */
+  scrollbar-width: none;
+}
+
+html.no-main-scrollbar::-webkit-scrollbar,
+body.no-main-scrollbar::-webkit-scrollbar {
+  /* Chrome, Edge, Safari */
+  display: none;
 }
 }
 

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -6,12 +6,19 @@
 @tailwind utilities;
 
 @layer base {
-  :root {
-    --enigma-ivory-cream: #FFF2E4;
-    --background: var(--enigma-ivory-cream);
-    --foreground: 0 0% 10%;
-    --primary:white;
-  }
+:root {
+  --enigma-ivory-cream: #FFF2E4;
+  --background: var(--enigma-ivory-cream);
+  --foreground: 0 0% 10%;
+  --primary:white;
+}
+
+html, body {
+  /* Prevent global page scroll; only internal scroll areas (like Play progress)
+     should scroll. */
+  height: 100%;
+  overflow: hidden;
+}
 }
 
 * {

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -13,11 +13,10 @@
   --primary:white;
 }
 
+/* Allow normal page scrolling again */
 html, body {
-  /* Prevent global page scroll; only internal scroll areas (like Play progress)
-     should scroll. */
-  height: 100%;
-  overflow: hidden;
+  height: auto;
+  overflow: auto;
 }
 }
 

--- a/apps/frontend/src/pages/AboutUs.tsx
+++ b/apps/frontend/src/pages/AboutUs.tsx
@@ -202,10 +202,18 @@ const AboutUs = () => {
   }, []);
   
   const desktopMinHeight = (DESKTOP_LAYOUT.inventoTop + DESKTOP_LAYOUT.sectionHeight + 100) * scaleFactor;
-  
+
+  // Hide the main page scrollbar visually while on the About Us page,
+  // but still allow scrolling with the mouse/trackpad.
   React.useEffect(() => {
-    document.body.style.overflow = 'hidden';
-    return () => { document.body.style.overflow = ''; };
+    const body = document.body;
+    const html = document.documentElement;
+    body.classList.add("no-main-scrollbar");
+    html.classList.add("no-main-scrollbar");
+    return () => {
+      body.classList.remove("no-main-scrollbar");
+      html.classList.remove("no-main-scrollbar");
+    };
   }, []);
   
   return (

--- a/apps/frontend/src/pages/PlayPage.tsx
+++ b/apps/frontend/src/pages/PlayPage.tsx
@@ -54,8 +54,8 @@ const DayBox = ({
         style={{ left, top }}
       />
       <div
-        className={`absolute font-whirlyBirdie font-bold ${textColor} text-center w-[89px] h-[24px] text-[20px] leading-[24px] whitespace-nowrap`}
-        style={{ left: `${parseFloat(left) + 18}px`, top: dayTop }}
+        className={`absolute font-whirlyBirdie font-bold ${textColor} text-center w-[110px] h-[24px] text-[18px] leading-[24px] whitespace-nowrap overflow-hidden`}
+        style={{ left: `${parseFloat(left) + 8}px`, top: dayTop }}
       >
         day {day}
       </div>

--- a/apps/frontend/src/pages/PlayPage.tsx
+++ b/apps/frontend/src/pages/PlayPage.tsx
@@ -192,6 +192,29 @@ function PlayPage() {
   const urlDay = day ? Number(day) : null;
   const loadingRef = useRef(false);
 
+  // Control main page scrollbar depending on route:
+  // - /play           → main scrollbar visible
+  // - /play/:day      → main scrollbar hidden (only internal scroll)
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const htmlEl = document.documentElement;
+    const bodyEl = document.body;
+
+    if (urlDay && !Number.isNaN(urlDay)) {
+      htmlEl.style.overflow = "hidden";
+      bodyEl.style.overflow = "hidden";
+    } else {
+      htmlEl.style.overflow = "";
+      bodyEl.style.overflow = "";
+    }
+
+    return () => {
+      htmlEl.style.overflow = "";
+      bodyEl.style.overflow = "";
+    };
+  }, [urlDay]);
+
   useEffect(() => {
     const updateScale = () => {
       if (window.innerWidth >= 1024) {

--- a/apps/frontend/src/pages/PlayPage.tsx
+++ b/apps/frontend/src/pages/PlayPage.tsx
@@ -192,16 +192,21 @@ function PlayPage() {
   const urlDay = day ? Number(day) : null;
   const loadingRef = useRef(false);
 
-  // Control main page scrollbar depending on route:
+  // Control main page scrollbar depending on route (desktop only):
   // - /play           → main scrollbar visible
-  // - /play/:day      → main scrollbar hidden (only internal scroll)
+  // - /play/:day      → main scrollbar hidden on desktop (≥1024px),
+  //                     but still visible on mobile so users can scroll.
   useEffect(() => {
     if (typeof window === "undefined") return;
 
     const htmlEl = document.documentElement;
     const bodyEl = document.body;
 
-    if (urlDay && !Number.isNaN(urlDay)) {
+    const isPlayDetail =
+      urlDay !== null && !Number.isNaN(urlDay) && Number.isFinite(urlDay);
+    const isDesktop = window.innerWidth >= 1024;
+
+    if (isPlayDetail && isDesktop) {
       htmlEl.style.overflow = "hidden";
       bodyEl.style.overflow = "hidden";
     } else {

--- a/apps/frontend/src/pages/PlayPage.tsx
+++ b/apps/frontend/src/pages/PlayPage.tsx
@@ -129,7 +129,9 @@ const ImageSquareWithLoader = ({
 // with however many questions exist in Firestore.
 const generateDayBoxes = (count: number) => {
   const baseLeft = 24.99;
-  const baseTop = 114;
+  // Base top is 0 because the scrollable container itself is positioned
+  // at top-[114px] inside the right panel.
+  const baseTop = 0;
   const colSpacing = 146.08;
   const rowSpacing = 114;
 
@@ -352,7 +354,7 @@ function PlayPage() {
       initial={{ opacity: 0, y: -20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6, ease: "easeOut" }}
-      className="min-h-screen bg-transparent relative overflow-y-auto"
+      className="min-h-screen bg-transparent relative overflow-hidden"
       ref={containerRef}
     >
       {/* Desktop Layout */}
@@ -485,31 +487,34 @@ function PlayPage() {
         )}
 
         {/* Right Rectangle */}
-        <div className="absolute bg-black w-[514px] h-[675px] left-[968.02px] top-[249px]">
+        <div className="absolute bg-black w-[514px] h-[675px] left-[968.02px] top-[249px] overflow-hidden">
           <div className="absolute font-whirlyBirdie font-bold text-white text-center w-[332px] h-[29px] left-[25px] top-[55px] text-[24px] leading-[29px]">
             Your progress
           </div>
 
-          {/* Day Boxes */}
-          {dayBoxes.map(({ day, left, top, dayTop, statusTop }) => {
-            const dayProgress = progress?.progress.find((p) => p.day === day);
-            return (
-              <DayBox
-                key={day}
-                day={day}
-                left={left}
-                top={top}
-                dayTop={dayTop}
-                statusTop={statusTop}
-                isCompleted={dayProgress?.isCompleted}
-                isAccessible={dayProgress?.isAccessible}
-                isDateUnlocked={dayProgress?.isDateUnlocked}
-              />
-            );
-          })}
-
-          {/* Progress Bar */}
-          <div className="absolute bg-white w-[15px] h-[523px] left-[473.99px] top-[114px]" />
+          {/* Scrollable Day Boxes + Progress Bar */}
+          <div className="absolute left-0 top-[114px] w-full h-[523px] overflow-y-auto internal-progress-scroll">
+            <div className="relative w-full h-max">
+              {dayBoxes.map(({ day, left, top, dayTop, statusTop }) => {
+                const dayProgress = progress?.progress.find(
+                  (p) => p.day === day,
+                );
+                return (
+                  <DayBox
+                    key={day}
+                    day={day}
+                    left={left}
+                    top={top}
+                    dayTop={dayTop}
+                    statusTop={statusTop}
+                    isCompleted={dayProgress?.isCompleted}
+                    isAccessible={dayProgress?.isAccessible}
+                    isDateUnlocked={dayProgress?.isDateUnlocked}
+                  />
+                );
+              })}
+            </div>
+          </div>
         </div>
       </div>
 

--- a/apps/frontend/src/pages/Rules.tsx
+++ b/apps/frontend/src/pages/Rules.tsx
@@ -48,13 +48,21 @@ const RuleFrame = ({ rule, index, isMobile }: RuleFrameProps) => {
 };
 // ========== MAIN COMPONENT ==========
 const Rules = () => {
+  // Hide the main page scrollbar visually while on the Rules page,
+  // but still allow scrolling with the mouse/trackpad.
   React.useEffect(() => {
-    document.body.style.overflow = 'hidden';
-    return () => { document.body.style.overflow = ''; };
+    const body = document.body;
+    const html = document.documentElement;
+    body.classList.add("no-main-scrollbar");
+    html.classList.add("no-main-scrollbar");
+    return () => {
+      body.classList.remove("no-main-scrollbar");
+      html.classList.remove("no-main-scrollbar");
+    };
   }, []);
 
   return (
-    <div className="relative w-full h-full overflow-y-auto overflow-x-hidden bg-[var(--page-bg,#f6efe6)]" data-rules-scroll>
+    <div className="relative w-full min-h-screen overflow-x-hidden bg-[var(--page-bg,#f6efe6)]" data-rules-scroll>
       <div className="hidden lg:block">
         <div className="absolute bg-black w-[1452px] h-[104px] left-[29.01px] top-[121px]" />
         <div className="absolute text-white font-whirlyBirdie font-bold w-[130px] h-[29px] left-[60.01px] top-[157px] text-[24px] leading-[29px]">RULES</div>


### PR DESCRIPTION
- Dynamic Play progress UI: Replace hard‑coded 5 day boxes with a grid generated from progress.totalDays, including a scrollable internal progress panel with a custom white-track / black-thumb scrollbar and improved “day X” label layout.

- Responsive scrolling behavior: Ensure the Play page only hides the main scrollbar on desktop for /play/:day, keeps it visible on mobile so users can scroll to the “Your progress” section, and uses internal scroll only where intended.

- Rules & About Us pages: Remove nested scrollbars and hide the main browser scrollbar via a shared no-main-scrollbar class so these pages scroll cleanly without double scrollbars.
